### PR TITLE
Fix & Optimize GPU training

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.ipynb filter=lfs diff=lfs merge=lfs -text
+*.py diff=python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v0.1.12 (2020-10-22)
+
+# Refactor
+
+- **modules**: add configured loggers
+- **data**: remove super slow mmap file warmup
+
+# Fix
+
+- **modules**: detach output tensors to avoid double backward pass
+- **samplers**: remove sampling more than max_tokens in a batch
+- **callbacks**: create parent dirs if they do not exist
+
 # v0.1.11 (2020-10-20)
 
 # Refactor

--- a/formerbox/data/mmap_dataset.py
+++ b/formerbox/data/mmap_dataset.py
@@ -19,12 +19,6 @@ from numpy import int32, int64
 from torch import Tensor
 
 
-def _warmup_mmap_file(filepath: Text) -> None:
-    with open(filepath, mode="rb") as stream:
-        while stream.read(100 * 1024 * 1024):
-            pass
-
-
 class MMapIndexedDatasetBase(IndexedDatasetBase, metaclass=ABCMeta):
     def __init__(self, filepath_prefix: Text) -> None:
         super().__init__(filepath_prefix)
@@ -55,8 +49,6 @@ class MMapIndexedDataset(MMapIndexedDatasetBase):
             self.length = length - 1  # has one extra (initial) item
             offset = index_file.tell()
 
-        _warmup_mmap_file(filepath)
-
         self.index_buffer_mmap = np.memmap(filepath, mode="r", order="C")
         assert self.index_buffer_mmap is not None
         self.index_buffer = memoryview(self.index_buffer_mmap)
@@ -78,7 +70,6 @@ class MMapIndexedDataset(MMapIndexedDatasetBase):
         )
 
     def read_data_file(self, filepath: Text) -> None:
-        _warmup_mmap_file(filepath)
         self.data_buffer_mmap = np.memmap(filepath, mode="r", order="C")
         assert self.data_buffer_mmap is not None
         self.data_buffer = memoryview(self.data_buffer_mmap)

--- a/formerbox/data/samplers/uniform_batch_sampler.py
+++ b/formerbox/data/samplers/uniform_batch_sampler.py
@@ -65,9 +65,10 @@ class UniformMaxTokensBatchSampler(UniformBatchSampler):
         current_index = 0
         while current_index < len(sorted_indices):
             index = sorted_indices[current_index]
-            batch_indices.append(index)
             batch_tokens += self.data_source.sizes[index]
-            current_index += 1
+            if batch_tokens <= self.max_tokens:
+                batch_indices.append(index)
+                current_index += 1
 
             if batch_tokens >= self.max_tokens:
                 batches.append(batch_indices)

--- a/formerbox/modules/transformer_datamodule.py
+++ b/formerbox/modules/transformer_datamodule.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Optional, Text, Type, Union
 
@@ -20,6 +21,8 @@ from transformers import (
 from typing_extensions import _ProtocolMeta  # type: ignore
 
 Tokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
+
+logger = logging.getLogger(__name__)
 
 
 class DataLoadingMixin:

--- a/formerbox/modules/transformer_module.py
+++ b/formerbox/modules/transformer_module.py
@@ -158,9 +158,13 @@ class TransformerModule(
         # model forward pass & prepare metrics values
         outputs = self.forward(**batch)
         assert outputs.loss is not None
-        # prepare clear tensors for logging
+
+        # prepare detached tensors for logging
         loss = outputs.loss.detach().cpu()
-        perplexity = self.perplexity(outputs.logits, batch["labels"])
+        logits = outputs.logits.detach()
+        labels = batch["labels"].detach()
+
+        perplexity = self.perplexity(logits, labels)
         perplexity = perplexity.detach().cpu()
         batch_size = torch.tensor(len(batch["input_ids"]))
 
@@ -196,9 +200,13 @@ class TransformerModule(
         # model forward pass & prepare metrics
         outputs = self.forward(**batch)
         assert outputs.loss is not None
-        # prepare clear tensors for logging
+
+        # prepare detached tensors for logging
         loss = outputs.loss.detach().cpu()
-        perplexity = self.perplexity(outputs.logits, batch["labels"])
+        logits = outputs.logits.detach()
+        labels = batch["labels"].detach()
+
+        perplexity = self.perplexity(logits, labels)
         perplexity = perplexity.detach().cpu()
 
         # log validation metrics

--- a/formerbox/modules/transformer_module.py
+++ b/formerbox/modules/transformer_module.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Text, Tuple, Type, Union
 
@@ -18,6 +19,8 @@ from transformers import PreTrainedModel, PreTrainedTokenizer, PreTrainedTokeniz
 from typing_extensions import Protocol
 
 Tokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
+
+logger = logging.getLogger(__name__)
 
 
 class TransformerModuleOutput(Protocol):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "formerbox"
-version = "0.1.11"
+version = "0.1.12"
 description = ""
 authors = ["mozharovsky <mozharovsky@live.com>"]
 


### PR DESCRIPTION
We've got some bugs and issues while testing it out in a GPU environment. This PR solves them.

## Patch Notes

* Fixed a bug with double backward pass which caused CUDA out of memory error
* Optimized `MMapIndexedDataset` cold loading time (more than 10x speedup)
* Fixed an issue in `UniformMaxTokensBatchSampler` that would produce batches with tokens exceeding the maximum number (`max_tokens`)